### PR TITLE
Added a little test chrome extension package

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,10 @@ Deployment for Serverless:
 
 - Use `npm run deploy:dev` to deploy to the Serverless development environment
 - Use `npm run deploy prod` to deploy to the Serverless development environment
+
+## Chrome Extension
+
+- To try out the extension, go to: `chrome://extensions/`
+- Make sure developer mode is switched to `on`
+- Click on `Load Unpacked` and select the `awsWiki` file from this codebase
+- Navigate to any page at `https://docs.aws.amazon.com/*` to see the extension work

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ For local development:
 - Run `sls offline start` in the terminal, which will spin up a local server at `localhost:3000` for local development
 - Routes are handled in `index.js`. Any edits will be reflected in real-time at `localhost:3000`
 
-Deployment to Serverless development environment:
+Deployment for Serverless:
 
-- Use `sls deploy` to deploy to the Serverless development environment
+- Use `npm run deploy:dev` to deploy to the Serverless development environment
+- Use `npm run deploy prod` to deploy to the Serverless development environment

--- a/awsWiki/content.js
+++ b/awsWiki/content.js
@@ -1,0 +1,7 @@
+//Just a sanity check that this works. It turns any image into a picture of a cat
+
+var images = document.getElementsByTagName("img");
+for (var i = 0, l = images.length; i < l; i++) {
+  images[i].src =
+    "http://placekitten.com/" + images[i].width + "/" + images[i].height;
+}

--- a/awsWiki/manifest.json
+++ b/awsWiki/manifest.json
@@ -1,10 +1,13 @@
 {
-    "name": "AWS Wiki",
-    "version": "1.0",
-    "description": "A living, breathing wiki providing human friendly AWS documention",
-    "background": {
-      "scripts": ["background.js"],
-      "persistent": false
-    },
-    "manifest_version": 2
-  }
+  "version": "0.0.0",
+  "name": "aws-wiki",
+  "manifest_version": 2,
+  "description":
+    "A living, breathing wiki providing human friendly AWS documention",
+  "content_scripts": [
+    {
+      "js": ["content.js"],
+      "matches": ["https://docs.aws.amazon.com/*"]
+    }
+  ]
+}


### PR DESCRIPTION
Updated the `manifest.json` to accept a js file and apply the .js file ONLY when it sees that the user is on any page on this domain: `https://docs.aws.amazon.com/*`
The current js file will turn any image on the page into an image of a cat.

To try out the extension, go to: `chrome://extensions/`
Make sure developer mode is switched to `on`
Click on `Load Unpacked` and select the `awsWiki` file from this codebase